### PR TITLE
convert.py: fix flake8 issues + sort imports with isort

### DIFF
--- a/convert-pth-to-ggml.py
+++ b/convert-pth-to-ggml.py
@@ -1,6 +1,8 @@
 # Compatibility stub
 
-import argparse, convert
+import argparse
+
+import convert
 
 parser = argparse.ArgumentParser(description='Convert a LLaMA model checkpoint to a ggml compatible file')
 parser.add_argument('dir_model',  help='directory containing the model checkpoint')

--- a/convert.py
+++ b/convert.py
@@ -1,11 +1,28 @@
-from sentencepiece import SentencePieceProcessor  # type: ignore
-import json, struct, re, zipfile, pickle, itertools, sys, enum, concurrent.futures
-import argparse, math, io, functools, mmap, signal, faulthandler, copy
-from pathlib import Path
-import numpy as np
+import argparse
+import concurrent.futures
+import copy
+import enum
+import faulthandler
+import functools
+import io
+import itertools
+import json
+import math
+import mmap
+import pickle
+import re
+import signal
+import struct
+import sys
+import zipfile
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Callable, Any, Iterable, IO, Sequence, Union, TypeVar, Literal
-from abc import abstractmethod, ABCMeta
+from pathlib import Path
+from typing import (IO, Any, Callable, Iterable, Literal, Optional, Sequence,
+                    TypeVar, Union)
+
+import numpy as np
+from sentencepiece import SentencePieceProcessor  # type: ignore
 
 faulthandler.register(signal.SIGUSR1)
 

--- a/convert.py
+++ b/convert.py
@@ -1,30 +1,34 @@
-from sentencepiece import SentencePieceProcessor # type: ignore
+from sentencepiece import SentencePieceProcessor  # type: ignore
 import json, struct, re, zipfile, pickle, itertools, sys, enum, concurrent.futures
-import argparse, math, io, functools, dataclasses, mmap, signal, faulthandler, copy
+import argparse, math, io, functools, mmap, signal, faulthandler, copy
 from pathlib import Path
 import numpy as np
 from dataclasses import dataclass
-from typing import Optional, Callable, Type, Any, Iterable, IO, Sequence, Union, TypeVar, Literal
+from typing import Optional, Callable, Any, Iterable, IO, Sequence, Union, TypeVar, Literal
 from abc import abstractmethod, ABCMeta
 
 faulthandler.register(signal.SIGUSR1)
 
 NDArray = np.ndarray[Any, Any]
 
+
 @dataclass(frozen=True)
 class UnquantizedDataType:
     name: str
+
 
 DT_F16 = UnquantizedDataType('F16')
 DT_F32 = UnquantizedDataType('F32')
 DT_I32 = UnquantizedDataType('I32')
 DT_BF16 = UnquantizedDataType('BF16')
 
+
 @dataclass(frozen=True)
 class QuantizedDataType:
     groupsize: int
     have_addends: bool
     have_g_idx: bool
+
 
 DT_Q4_0 = QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
 DT_Q4_1 = QuantizedDataType(groupsize=32, have_addends=True, have_g_idx=False)
@@ -48,12 +52,13 @@ DATA_TYPE_TO_NUMPY: dict[DataType, np.dtype[Any]] = {
 
 NUMPY_TYPE_TO_DATA_TYPE: dict[np.dtype[Any], DataType] = {dtype: data_type for (data_type, dtype) in DATA_TYPE_TO_NUMPY.items()}
 
+
 class GGMLFileType(enum.Enum):
     AllF32 = 0
-    MostlyF16 = 1 # except 1d tensors
-    MostlyQ4_0 = 2 # except 1d tensors
-    MostlyQ4_1 = 3 # except 1d tensors
-    PerLayerIsQ4_1 = 4 # but tok_embeddings.weight and output.weight are F16
+    MostlyF16 = 1  # except 1d tensors
+    MostlyQ4_0 = 2  # except 1d tensors
+    MostlyQ4_1 = 3  # except 1d tensors
+    PerLayerIsQ4_1 = 4  # but tok_embeddings.weight and output.weight are F16
 
     def type_for_tensor(self, name: str, tensor: 'LazyTensor') -> DataType:
         if len(tensor.shape) == 1:
@@ -75,13 +80,14 @@ class GGMLFileType(enum.Enum):
         else:
             raise ValueError(self)
 
+
 def make_tensors_list() -> list[str]:
     ret = [
         'tok_embeddings.weight',
         'norm.weight',
         'output.weight',
     ]
-    for i in range(80): # maximum number of layer
+    for i in range(80):  # maximum number of layer
         ret += [
             f'layers.{i}.attention.wq.weight',
             f'layers.{i}.attention.wk.weight',
@@ -95,8 +101,11 @@ def make_tensors_list() -> list[str]:
             f'layers.{i}.ffn_norm.weight',
         ]
     return ret
+
+
 TENSORS_LIST = make_tensors_list()
 TENSORS_SET = set(TENSORS_LIST)
+
 
 @dataclass
 class Params:
@@ -112,13 +121,14 @@ class Params:
         n_vocab, n_embd = model["tok_embeddings.weight"].shape
 
         return Params(
-            n_vocab = n_vocab,
-            n_embd = n_embd,
-            n_mult = 256,
-            n_head = n_embd // 128,
-            n_layer = next(i for i in itertools.count() if f"layers.{i}.attention.wq.weight" not in model),
-            file_type = file_type,
+            n_vocab=n_vocab,
+            n_embd=n_embd,
+            n_mult=256,
+            n_head=n_embd // 128,
+            n_layer=next(i for i in itertools.count() if f"layers.{i}.attention.wq.weight" not in model),
+            file_type=file_type,
         )
+
 
 class SentencePieceVocab:
     def __init__(self, fname_tokenizer: Path, fname_added_tokens: Optional[Path]) -> None:
@@ -171,6 +181,7 @@ class SentencePieceVocab:
     def __repr__(self) -> str:
         return f"<SentencePieceVocab with {self.vocab_size_base} base tokens and {len(self.added_tokens_list)} added tokens>"
 
+
 class GGMLVocab:
     def __init__(self, tokens: list[tuple[bytes, float]]):
         self.tokens = tokens
@@ -182,12 +193,15 @@ class GGMLVocab:
     def __repr__(self) -> str:
         return f"<GGMLVocab with {self.vocab_size} tokens>"
 
+
 Vocab = Union[SentencePieceVocab, GGMLVocab]
+
 
 def permute(weights: NDArray, n_head: int) -> NDArray:
     return (weights.reshape(n_head, 2, weights.shape[0] // n_head // 2, *weights.shape[1:])
                    .swapaxes(1, 2)
                    .reshape(weights.shape))
+
 
 def dequantize_q4(qvalues_pack32: NDArray, scales: NDArray, addends: Optional[NDArray], g_idx: Optional[NDArray]) -> NDArray:
     # First reinterpret each row from a list of int32s containing 8 values each
@@ -227,6 +241,7 @@ def dequantize_q4(qvalues_pack32: NDArray, scales: NDArray, addends: Optional[ND
         values.shape = (values.shape[0], values.shape[1] * values.shape[2])
     return values
 
+
 class Tensor(metaclass=ABCMeta):
     data_type: DataType
 
@@ -237,18 +252,23 @@ class Tensor(metaclass=ABCMeta):
     @abstractmethod
     def to_ggml(self) -> 'GGMLCompatibleTensor': ...
 
+
 class UnquantizedTensor(Tensor):
     def __init__(self, ndarray: NDArray) -> None:
         assert isinstance(ndarray, np.ndarray)
         self.ndarray = ndarray
         self.data_type = NUMPY_TYPE_TO_DATA_TYPE[ndarray.dtype]
+
     def astype(self, data_type: DataType) -> Tensor:
         dtype = DATA_TYPE_TO_NUMPY[data_type]
         return UnquantizedTensor(self.ndarray.astype(dtype))
+
     def to_ggml(self) -> 'UnquantizedTensor':
         return self
+
     def permute(self, n_head: int) -> 'UnquantizedTensor':
         return UnquantizedTensor(permute(self.ndarray, n_head))
+
 
 def load_unquantized(lazy_tensor: 'LazyTensor', expected_dtype: Any = None) -> NDArray:
     tensor = lazy_tensor.load()
@@ -262,12 +282,14 @@ def load_unquantized(lazy_tensor: 'LazyTensor', expected_dtype: Any = None) -> N
 
     return tensor.ndarray
 
+
 class GGMLQuantizedTensor(Tensor):
     data_type: QuantizedDataType
+
     def __init__(self, ndarray: NDArray, shape: list[int], data_type: DataType) -> None:
         rows, columns = shape
-        assert data_type in (DT_Q4_1, DT_Q4_0) # for now
-        assert isinstance(data_type, QuantizedDataType) # redundant, but mypy complains without this
+        assert data_type in (DT_Q4_1, DT_Q4_0)  # for now
+        assert isinstance(data_type, QuantizedDataType)  # redundant, but mypy complains without this
         assert columns % data_type.groupsize == 0
         words_in_block = 6 if data_type == DT_Q4_1 else 5
         self.ndarray = ndarray.view(dtype=np.uint32).reshape((rows, columns // data_type.groupsize, words_in_block))
@@ -293,7 +315,9 @@ class GGMLQuantizedTensor(Tensor):
     def permute(self, n_head: int) -> 'GGMLQuantizedTensor':
         return GGMLQuantizedTensor(permute(self.ndarray, n_head), self.shape, self.data_type)
 
+
 GGMLCompatibleTensor = Union[UnquantizedTensor, GGMLQuantizedTensor]
+
 
 class DeferredPermutedTensor(Tensor):
     def __init__(self, base: Tensor, n_head: int) -> None:
@@ -309,6 +333,7 @@ class DeferredPermutedTensor(Tensor):
 
     def permute(self, n_head: int) -> Tensor:
         raise Exception("shouldn't permute twice")
+
 
 class GPTQForLLaMaQuantizedTensor(Tensor):
     def __init__(self, model: 'LazyModel', namebase: str) -> None:
@@ -351,7 +376,6 @@ class GPTQForLLaMaQuantizedTensor(Tensor):
         else:
             self.g_idx = None
 
-
         self.shape = [self.qweight.shape[0], self.qweight.shape[1] * 8]
         self.data_type = QuantizedDataType(groupsize=self.groupsize(), have_addends=True,
                                            have_g_idx=(self.g_idx is not None))
@@ -372,7 +396,7 @@ class GPTQForLLaMaQuantizedTensor(Tensor):
 
     def astype(self, data_type: DataType) -> Tensor:
         if isinstance(data_type, QuantizedDataType):
-            assert self.g_idx is None and data_type.have_addends == True and data_type.have_g_idx == False
+            assert self.g_idx is None and data_type.have_addends is True and data_type.have_g_idx is False
             return self.regroup(data_type.groupsize)
 
         dequantized = dequantize_q4(np.ascontiguousarray(self.qweight), self.scales, self.addends, self.g_idx)
@@ -413,7 +437,6 @@ class GPTQForLLaMaQuantizedTensor(Tensor):
         if self.groupsize() != 32:
             raise Exception("should have been regrouped before converting to ggml")
 
-
         # Since the output format is mixed between integers and floats, we have
         # to hackily view the floats as int32s just so numpy will let us
         # concatenate them.
@@ -427,6 +450,7 @@ class GPTQForLLaMaQuantizedTensor(Tensor):
         grouped = np.concatenate([scales_view, addends_view, grouped], axis=2, casting='no')
 
         return GGMLQuantizedTensor(grouped, self.shape, DT_Q4_1)
+
 
 @dataclass
 class LazyTensor:
@@ -442,6 +466,7 @@ class LazyTensor:
 
     def astype(self, data_type: DataType) -> 'LazyTensor':
         self.validate_conversion_to(data_type)
+
         def load() -> Tensor:
             return self.load().astype(data_type)
         return LazyTensor(load, self.shape, data_type, f'convert({data_type}) {self.description}')
@@ -460,17 +485,20 @@ class LazyTensor:
 
 LazyModel = dict[str, LazyTensor]
 
+
 @dataclass
 class ModelPlus:
     model: LazyModel
-    paths: list[Path] # Where this was read from.
+    paths: list[Path]  # Where this was read from.
     format: Literal['ggml', 'torch', 'safetensors']
-    vocab: Optional[Vocab] # For GGML models (which have vocab built in), the vocab.
+    vocab: Optional[Vocab]  # For GGML models (which have vocab built in), the vocab.
+
 
 def merge_sharded(models: list[LazyModel]) -> LazyModel:
     # Original LLaMA models have each file contain one part of each tensor.
     # Use a dict instead of a set to preserve order.
     names = {name: None for model in models for name in model}
+
     def convert(name: str) -> LazyTensor:
         lazy_tensors: list[LazyTensor] = [model[name] for model in models]
         if len(lazy_tensors) == 1:
@@ -480,9 +508,9 @@ def merge_sharded(models: list[LazyModel]) -> LazyModel:
         if len(lazy_tensors[0].shape) == 1:
             # the tensor is just duplicated in every file
             return lazy_tensors[0]
-        if (name.startswith('tok_embeddings.') or
-            name.endswith('.attention.wo.weight') or
-            name.endswith('.feed_forward.w2.weight')):
+        if name.startswith('tok_embeddings.') or \
+           name.endswith('.attention.wo.weight') or \
+           name.endswith('.feed_forward.w2.weight'):
             # split by columns
             axis = 1
         else:
@@ -490,6 +518,7 @@ def merge_sharded(models: list[LazyModel]) -> LazyModel:
             axis = 0
         concatenated_shape = list(lazy_tensors[0].shape)
         concatenated_shape[axis] = sum(tensor.shape[axis] for tensor in lazy_tensors)
+
         def load() -> UnquantizedTensor:
             ndarrays = [load_unquantized(tensor) for tensor in lazy_tensors]
             concatenated: NDArray = np.concatenate(ndarrays, axis=axis)
@@ -497,6 +526,7 @@ def merge_sharded(models: list[LazyModel]) -> LazyModel:
         description = 'concatenated[[' + '] | ['.join(lt.description for lt in lazy_tensors) + ']]'
         return LazyTensor(load, concatenated_shape, lazy_tensors[0].data_type, description)
     return {name: convert(name) for name in names}
+
 
 def merge_multifile_models(models_plus: list[ModelPlus]) -> ModelPlus:
     formats = set(mp.format for mp in models_plus)
@@ -520,10 +550,12 @@ def merge_multifile_models(models_plus: list[ModelPlus]) -> ModelPlus:
 
     return ModelPlus(model, paths, format, vocab)
 
+
 def permute_lazy(lazy_tensor: LazyTensor, n_head: int) -> LazyTensor:
     def load() -> Tensor:
         return lazy_tensor.load().permute(n_head)
     return LazyTensor(load, lazy_tensor.shape, lazy_tensor.data_type, f'permute({n_head}) ' + lazy_tensor.description)
+
 
 def convert_transformers_to_orig(model: LazyModel) -> LazyModel:
     out: LazyModel = {}
@@ -531,7 +563,7 @@ def convert_transformers_to_orig(model: LazyModel) -> LazyModel:
     out["norm.weight"] = model["model.norm.weight"]
     out["output.weight"] = model["lm_head.weight"]
 
-    n_head = model[f"model.layers.0.self_attn.q_proj.weight"].shape[1] // 128
+    n_head = model["model.layers.0.self_attn.q_proj.weight"].shape[1] // 128
     for i in itertools.count():
         if f"model.layers.{i}.self_attn.q_proj.weight" not in model:
             break
@@ -547,6 +579,7 @@ def convert_transformers_to_orig(model: LazyModel) -> LazyModel:
         out[f"layers.{i}.attention_norm.weight"] = model[f"model.layers.{i}.input_layernorm.weight"]
         out[f"layers.{i}.ffn_norm.weight"] = model[f"model.layers.{i}.post_attention_layernorm.weight"]
     return out
+
 
 def handle_quantization(model: LazyModel) -> LazyModel:
     '''Convert a model with entries for 'foo.qweight', 'foo.scales', etc.
@@ -587,20 +620,26 @@ def handle_quantization(model: LazyModel) -> LazyModel:
 # This allows us to de-shard without multiplying RAM usage, and also
 # conveniently drops the PyTorch dependency (though we still need numpy).
 
+
 @dataclass
 class LazyStorageKind:
     data_type: DataType
+
+
 @dataclass
 class LazyStorage:
     load: Callable[[int, int], NDArray]
     kind: LazyStorageKind
     description: str
 
+
 class LazyUnpickler(pickle.Unpickler):
+
     def __init__(self, fp: IO[bytes], data_base_path: str, zip_file: zipfile.ZipFile):
         super().__init__(fp)
         self.data_base_path = data_base_path
         self.zip_file = zip_file
+
     def persistent_load(self, pid: Any) -> Any:
         assert pid[0] == 'storage'
         assert isinstance(pid[1], LazyStorageKind)
@@ -608,6 +647,7 @@ class LazyUnpickler(pickle.Unpickler):
         filename_stem = pid[2]
         filename = self.data_base_path + '/' + filename_stem
         info = self.zip_file.getinfo(filename)
+
         def load(offset: int, elm_count: int) -> NDArray:
             dtype = DATA_TYPE_TO_NUMPY.get(data_type)
             if dtype is None:
@@ -624,6 +664,7 @@ class LazyUnpickler(pickle.Unpickler):
     @staticmethod
     def lazy_rebuild_tensor_v2(storage: Any, storage_offset: Any, size: Any, stride: Any, requires_grad: Any, backward_hooks: Any, metadata: Any = None) -> LazyTensor:
         assert isinstance(storage, LazyStorage)
+
         def load() -> UnquantizedTensor:
             elm_count = stride[0] * size[0]
             return UnquantizedTensor(storage.load(storage_offset, elm_count).reshape(size))
@@ -637,10 +678,12 @@ class LazyUnpickler(pickle.Unpickler):
         ('torch', 'FloatStorage'): LazyStorageKind(DT_F32),
         ('torch', 'IntStorage'): LazyStorageKind(DT_I32),
     }
+
     def find_class(self, module: str, name: str) -> Any:
         if not module.startswith('torch'):
             return super().find_class(module, name)
         return self.CLASSES[(module, name)]
+
 
 def lazy_load_torch_file(outer_fp: IO[bytes], path: Path) -> ModelPlus:
     zf = zipfile.ZipFile(outer_fp)
@@ -648,24 +691,27 @@ def lazy_load_torch_file(outer_fp: IO[bytes], path: Path) -> ModelPlus:
     assert len(pickle_paths) == 1, pickle_paths
     pickle_fp = zf.open(pickle_paths[0], 'r')
     unpickler = LazyUnpickler(pickle_fp,
-        data_base_path = pickle_paths[0][:-4],
-        zip_file = zf)
+                              data_base_path=pickle_paths[0][:-4],
+                              zip_file=zf)
     model = unpickler.load()
     as_dict = dict(model.items())
     return ModelPlus(model=as_dict, paths=[path], format='torch', vocab=None)
+
 
 SAFETENSORS_DATA_TYPES: dict[str, DataType] = {
     'F16': DT_F16,
     'F32': DT_F32,
     'I32': DT_I32,
 }
+
+
 def lazy_load_safetensors_file(fp: IO[bytes], path: Path) -> ModelPlus:
     header_size, = struct.unpack('<Q', fp.read(8))
     header: dict[str, dict[str, Any]] = json.loads(fp.read(header_size))
     # Use mmap for the actual data to avoid race conditions with the file offset.
     mapped = memoryview(mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ))
     byte_buf = mapped[fp.tell():]
-    out: LazyModel = {}
+
     def convert(info: dict[str, Any]) -> LazyTensor:
         data_type = SAFETENSORS_DATA_TYPES[info['dtype']]
         numpy_dtype = DATA_TYPE_TO_NUMPY[data_type]
@@ -674,6 +720,7 @@ def lazy_load_safetensors_file(fp: IO[bytes], path: Path) -> ModelPlus:
         assert 0 <= begin <= end <= len(byte_buf)
         assert end - begin == math.prod(shape) * numpy_dtype.itemsize
         buf = byte_buf[begin:end]
+
         def load() -> UnquantizedTensor:
             return UnquantizedTensor(np.frombuffer(buf, dtype=numpy_dtype).reshape(shape))
         description = f'safetensors begin={begin} end={end} type={data_type} path={path}'
@@ -681,17 +728,20 @@ def lazy_load_safetensors_file(fp: IO[bytes], path: Path) -> ModelPlus:
     model = {name: convert(info) for (name, info) in header.items()}
     return ModelPlus(model=model, paths=[path], format='safetensors', vocab=None)
 
+
 def must_read(fp: IO[bytes], length: int) -> bytes:
     ret = fp.read(length)
     if len(ret) < length:
         raise Exception("unexpectedly reached end of file")
     return ret
 
+
 def lazy_load_ggml_file(fp: IO[bytes], path: Path) -> ModelPlus:
     magic = must_read(fp, 4)[::-1]
-    #version: Optional[int]
+    # version: Optional[int]
     if magic in (b'ggmf', b'ggjt'):
         version, = struct.unpack("i", must_read(fp, 4))
+        assert version == 1
     else:
         assert magic == b'ggml'
         version = None
@@ -722,7 +772,8 @@ def lazy_load_ggml_file(fp: IO[bytes], path: Path) -> ModelPlus:
     model: LazyModel = {}
     # Use mmap for the actual data to avoid race conditions with the file offset.
     mapped = memoryview(mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ))
-    def read_tensor() -> None: # this is a function so that variables captured in `load` don't change
+
+    def read_tensor() -> None:  # this is a function so that variables captured in `load` don't change
         shape_len, name_len, ftype = struct.unpack("iii", must_read(fp, 12))
         assert 0 <= shape_len <= 3
         shape: list[int] = list(struct.unpack(f"{shape_len}i", must_read(fp, 4 * shape_len)))
@@ -761,6 +812,7 @@ def lazy_load_ggml_file(fp: IO[bytes], path: Path) -> ModelPlus:
 
     return ModelPlus(model=model, paths=[path], format='ggml', vocab=vocab)
 
+
 @functools.cache
 def lazy_load_file(path: Path) -> ModelPlus:
     fp = open(path, 'rb')
@@ -778,8 +830,11 @@ def lazy_load_file(path: Path) -> ModelPlus:
     else:
         raise ValueError(f"unknown format: {path}")
 
+
 In = TypeVar('In')
 Out = TypeVar('Out')
+
+
 def bounded_parallel_map(func: Callable[[In], Out], iterable: Iterable[In], concurrency: int) -> Iterable[Out]:
     '''Parallel map, but with backpressure.  If the caller doesn't call `next`
     fast enough, this will stop calling `func` at some point rather than
@@ -795,6 +850,7 @@ def bounded_parallel_map(func: Callable[[In], Out], iterable: Iterable[In], conc
             if items_rev:
                 futures.append(executor.submit(func, items_rev.pop()))
             yield result
+
 
 def check_vocab_size(params: Params, vocab: Vocab) -> None:
     if params.n_vocab != vocab.vocab_size:
@@ -813,14 +869,15 @@ def check_vocab_size(params: Params, vocab: Vocab) -> None:
             msg += f"  Most likely you are missing added_tokens.json (should be in {vocab.fname_tokenizer.parent})."
         raise Exception(msg)
 
+
 class OutputFile:
     def __init__(self, fname_out: Path) -> None:
         self.fout = open(fname_out, "wb")
 
     def write_file_header(self, params: Params) -> None:
-        self.fout.write(b"ggjt"[::-1]) # magic
+        self.fout.write(b"ggjt"[::-1])  # magic
         values = [
-            1, # file version
+            1,  # file version
             params.n_vocab,
             params.n_embd,
             params.n_mult,
@@ -847,8 +904,8 @@ class OutputFile:
     @staticmethod
     def write_vocab_only(fname_out: Path, vocab: Vocab) -> None:
         of = OutputFile(fname_out)
-        params = Params(n_vocab = vocab.vocab_size, n_embd = 0, n_mult = 0,
-                        n_head = 1, n_layer = 0, file_type = GGMLFileType.AllF32)
+        params = Params(n_vocab=vocab.vocab_size, n_embd=0, n_mult=0,
+                        n_head=1, n_layer=0, file_type=GGMLFileType.AllF32)
         of = OutputFile(fname_out)
         of.write_file_header(params)
         of.write_vocab(vocab)
@@ -859,7 +916,7 @@ class OutputFile:
         check_vocab_size(params, vocab)
         of = OutputFile(fname_out)
         of.write_file_header(params)
-        print(f"Writing vocab...")
+        print("Writing vocab...")
         of.write_vocab(vocab)
 
         def do_item(item: tuple[str, LazyTensor]) -> NDArray:
@@ -874,6 +931,7 @@ class OutputFile:
             ndarray.tofile(of.fout)
         of.fout.close()
 
+
 def pick_output_type(model: LazyModel, output_type_str: Optional[str]) -> GGMLFileType:
     wq_type = model["layers.0.attention.wq.weight"].data_type
     if output_type_str == "f32" or (output_type_str is None and wq_type == DT_F32):
@@ -887,9 +945,10 @@ def pick_output_type(model: LazyModel, output_type_str: Optional[str]) -> GGMLFi
         else:
             return GGMLFileType.PerLayerIsQ4_1
     if output_type_str == "q4_0" or (output_type_str is None and isinstance(wq_type, QuantizedDataType)):
-            return GGMLFileType.MostlyQ4_0
+        return GGMLFileType.MostlyQ4_0
     name_to_type = {name: lazy_tensor.data_type for (name, lazy_tensor) in model.items()}
     raise Exception(f"Unexpected combination of types: {name_to_type}")
+
 
 def do_necessary_conversions(model: LazyModel) -> LazyModel:
     model = handle_quantization(model)
@@ -900,9 +959,10 @@ def do_necessary_conversions(model: LazyModel) -> LazyModel:
 
     return model
 
+
 def convert_to_output_type(model: LazyModel, output_type: GGMLFileType) -> LazyModel:
     return {name: tensor.astype(output_type.type_for_tensor(name, tensor))
-        for (name, tensor) in model.items()}
+            for (name, tensor) in model.items()}
 
 
 def nth_multifile_path(path: Path, n: int) -> Optional[Path]:
@@ -925,6 +985,7 @@ def nth_multifile_path(path: Path, n: int) -> Optional[Path]:
                 return new_path
     return None
 
+
 def find_multifile_paths(path: Path) -> list[Path]:
     '''Given any path belonging to a multi-file model (e.g. foo.bin.1), return
     the whole list of paths in the model.
@@ -941,6 +1002,7 @@ def find_multifile_paths(path: Path) -> list[Path]:
         # as a single file.
         return [path]
     return ret
+
 
 def load_some_model(path: Path) -> ModelPlus:
     '''Load a model of any supported format.'''
@@ -968,8 +1030,10 @@ def load_some_model(path: Path) -> ModelPlus:
     model_plus = merge_multifile_models(models_plus)
     return model_plus
 
+
 def filter_and_sort_tensors(model: LazyModel) -> LazyModel:
     return {name: model[name] for name in TENSORS_LIST if name in model}
+
 
 def load_vocab(path: Path) -> SentencePieceVocab:
     # Be extra-friendly and accept either a file or a directory.  Also, if it's
@@ -989,6 +1053,7 @@ def load_vocab(path: Path) -> SentencePieceVocab:
     print(f"Loading vocab file {path}")
     return SentencePieceVocab(path, added_tokens_path if added_tokens_path.exists() else None)
 
+
 def default_outfile(model_paths: list[Path], params: Params) -> Path:
     namestr = {
         GGMLFileType.AllF32: "f32",
@@ -1002,12 +1067,14 @@ def default_outfile(model_paths: list[Path], params: Params) -> Path:
         sys.exit(1)
     return ret
 
+
 def do_dump_model(model_plus: ModelPlus) -> None:
     print(f"model_plus.paths = {model_plus.paths!r}")
     print(f"model_plus.format = {model_plus.format!r}")
     print(f"model_plus.vocab = {model_plus.vocab!r}")
     for name, lazy_tensor in model_plus.model.items():
         print(f"{name}: shape={lazy_tensor.shape} type={lazy_tensor.data_type}; {lazy_tensor.description}")
+
 
 def main(args_in: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Convert a LLaMa model to a GGML compatible file")
@@ -1048,6 +1115,7 @@ def main(args_in: Optional[list[str]] = None) -> None:
         outfile = args.outfile or default_outfile(model_plus.paths, params)
         OutputFile.write_all(outfile, params, model, vocab)
         print(f"Wrote {outfile}")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Just sending my two cleanup commits before https://github.com/ggerganov/llama.cpp/pull/545 is merged.

Most of flake8 issues are whitespace related, but there are also some unnecessary import removals